### PR TITLE
🎏 Add Airflow runtime build arguments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          build-args: |
+            AIRFLOW_RUNTIME_VERSION=${{ github.ref_name }}
 
       - name: Sign
         id: sign

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,13 @@ LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.description="Airflow Python base image for Analytical Platform" \
       org.opencontainers.image.url="https://github.com/ministryofjustice/analytical-platform-airflow-python-base"
 
+ARG AIRFLOW_RUNTIME_VERSION="default"
+
 ENV CONTAINER_USER="analyticalplatform" \
     CONTAINER_UID="1000" \
     CONTAINER_GROUP="analyticalplatform" \
     CONTAINER_GID="1000" \
+    AIRFLOW_RUNTIME="python" \
     ANALYTICAL_PLATFORM_DIRECTORY="/opt/analyticalplatform" \
     DEBIAN_FRONTEND="noninteractive" \
     PIP_BREAK_SYSTEM_PACKAGES="1" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV CONTAINER_USER="analyticalplatform" \
     CONTAINER_GROUP="analyticalplatform" \
     CONTAINER_GID="1000" \
     AIRFLOW_RUNTIME="python" \
+    AIRFLOW_RUNTIME_VERSION="${AIRFLOW_RUNTIME_VERSION}" \
     ANALYTICAL_PLATFORM_DIRECTORY="/opt/analyticalplatform" \
     DEBIAN_FRONTEND="noninteractive" \
     PIP_BREAK_SYSTEM_PACKAGES="1" \


### PR DESCRIPTION
## Proposed Changes

- Adds `AIRFLOW_RUNTIME` and `AIRFLOW_RUNTIME_VERSION`

## Notes for the reviewer

I am trying to determine the base image in (https://github.com/ministryofjustice/analytical-platform-airflow/pull/102), but unable to. Adding these args so I can retrieve them with inspection.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>