### PR TITLE
Add alert to trivy ignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -6,3 +6,6 @@ AVD-DS-0029 exp:2026-04-28
 
 ## Trivy: Healthchecks applied downstream
 AVD-DS-0026 exp:2026-04-28
+
+## as of 06/05/2026 uv has not released a version containing the dependency upgrade.
+GHSA-82j2-j2ch-gfr8 exp:2026-05-20


### PR DESCRIPTION
This pull request makes a minor update to the `.trivyignore` file by adding an entry to ignore a new security advisory for a dependency that has not yet been upgraded upstream.

* [`.trivyignore`](diffhunk://#diff-a2b39041fe7520e8037b4e596d015ea4825043e383f3fa5f85d5ac7f06f4c177R9-R11): Added an ignore entry for `GHSA-82j2-j2ch-gfr8` with an expiration date, noting that the dependency upgrade is not yet available in upstream releases.