### PR TITLE
updating workflows

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -17,6 +17,6 @@ jobs:
       contents: write
       id-token: write
       packages: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml@f3b2ed398ec5c17e2f59d983bc01c79c73632246 # v7.3.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1
     secrets:
       release-failure-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_RELEASE_FAILURE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -6,14 +6,15 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  pull-requests: write
-  id-token: write
+permissions: {}
 
 jobs:
   container-scan:
-    name: Container Scan
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+      security-events: write
     uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@feat/grype-scanning # v5.1.0
     with:
       runtime: python

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -14,6 +14,6 @@ permissions:
 jobs:
   container-scan:
     name: Container Scan
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@5df18d64ab85a164f7241c38447c4575f1a85f40 # v5.1.0
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@5feat/grype/scanning # v5.1.0
     with:
       runtime: python

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -14,6 +14,6 @@ permissions:
 jobs:
   container-scan:
     name: Container Scan
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@5feat/grype/scanning # v5.1.0
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@feat/grype/scanning # v5.1.0
     with:
       runtime: python

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -14,6 +14,6 @@ permissions:
 jobs:
   container-scan:
     name: Container Scan
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@feat/grype/scanning # v5.1.0
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@feat/grype-scanning # v5.1.0
     with:
       runtime: python

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -15,6 +15,6 @@ jobs:
       id-token: write
       pull-requests: write
       security-events: write
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@feat/grype-scanning # v5.1.0
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@ee7af2fc5379dc235ced9f93378cbca973d9e5ad # v6.0.0
     with:
       runtime: python

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -13,4 +13,4 @@ jobs:
     name: Container Test
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-test.yml@f3b2ed398ec5c17e2f59d983bc01c79c73632246 # v7.3.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-test.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,4 +14,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-dependency-review.yml@f3b2ed398ec5c17e2f59d983bc01c79c73632246 # v7.3.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-dependency-review.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -14,6 +14,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scheduled-container-scan.yml@9fbe4cbba23d4a768eb36462458a4cfcb63682e1 # v5.2.0
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scheduled-container-scan.yml@ee7af2fc5379dc235ced9f93378cbca973d9e5ad # v6.0.0
     secrets:
       cve-scan-slack-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_CVE_SCAN_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,4 +16,4 @@ jobs:
       packages: read
       pull-requests: write
       statuses: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@f3b2ed398ec5c17e2f59d983bc01c79c73632246 # v7.3.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,4 +15,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-zizmor.yml@f3b2ed398ec5c17e2f59d983bc01c79c73632246 # v7.3.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-zizmor.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1

--- a/.grype.yml
+++ b/.grype.yml
@@ -1,0 +1,7 @@
+---
+# Grype configuration file for container vulnerability scanning
+# https://oss.anchore.com/docs/reference/grype/configuration/
+
+ignore:
+  - vulnerability: CVE-2026-7210
+  # Patched upstream, awaiting base image update - see README on how to check for updates.

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,8 +1,0 @@
-# As of 20/02/2025 there are no CRITICAL or HIGH CVEs for this image
-
-## Trivy: misreading due to heredoc structure
-AVD-DS-0017 exp:2026-04-28
-AVD-DS-0029 exp:2026-04-28
-
-## Trivy: Healthchecks applied downstream
-AVD-DS-0026 exp:2026-04-28

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - Health checks are implemented downstream of this image
 
-FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:748740465d0aadaa69ab6e6c295892f17d7a8f44a85090dbb571ec0bb8c5674f
+FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:8c10ecc59261c77dd866fa8587f1b9cbf172ad8f1253f0af96eaae0fa390c132
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ apt-get install --yes \
   "curl=8.5.0-2ubuntu10.9" \
   "git=1:2.43.0-1ubuntu7.3" \
   "jq=1.7.1-3ubuntu0.24.04.2" \
+  "libgnutls30t64=3.8.3-1.1ubuntu3.6" \
   "python3.12=3.12.3-1ubuntu0.13" \
   "python3-pip=24.0+dfsg-1ubuntu1.3" \
   "unzip=6.0-28ubuntu4.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,14 @@ ENV CONTAINER_USER="analyticalplatform" \
     ANALYTICAL_PLATFORM_DIRECTORY="/opt/analyticalplatform" \
     DEBIAN_FRONTEND="noninteractive" \
     PIP_BREAK_SYSTEM_PACKAGES="1" \
-    AWS_CLI_VERSION="2.34.39" \
-    CUDA_VERSION="13.1.0" \
+    AWS_CLI_VERSION="2.35.8" \
+    CUDA_VERSION="13.2.0" \
     NVIDIA_DISABLE_REQUIRE="true" \
-    NVIDIA_CUDA_COMPAT_VERSION="590.48.01-0ubuntu1" \
-    NVIDIA_CUDA_CUDART_VERSION="13.1.80-1" \
+    NVIDIA_CUDA_COMPAT_VERSION="595.71.05-1ubuntu1" \
+    NVIDIA_CUDA_CUDART_VERSION="13.2.75-1" \
     NVIDIA_VISIBLE_DEVICES="all" \
     NVIDIA_DRIVER_CAPABILITIES="compute,utility" \
-    UV_VERSION="0.11.9" \
+    UV_VERSION="0.11.22" \
     LD_LIBRARY_PATH="/usr/local/nvidia/lib:/usr/local/nvidia/lib64" \
     PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/home/analyticalplatform/.local/bin:${PATH}"
 
@@ -106,8 +106,8 @@ echo "deb [signed-by=/etc/apt/keyrings/nvidia.gpg] https://developer.download.nv
 apt-get update --yes
 
 apt-get install --yes \
-  "cuda-cudart-13-1=${NVIDIA_CUDA_CUDART_VERSION}" \
-  "cuda-compat-13-1=${NVIDIA_CUDA_COMPAT_VERSION}"
+  "cuda-cudart-13-2=${NVIDIA_CUDA_CUDART_VERSION}" \
+  "cuda-compat-13-2=${NVIDIA_CUDA_COMPAT_VERSION}"
 
 echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf
 echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ echo "deb [signed-by=/etc/apt/keyrings/nvidia.gpg] https://developer.download.nv
 
 apt-get update --yes
 
-apt-cache policy cuda-cudart-13-1
+apt-cache policy cuda-cudart-13-2
 
-apt-cache policy cuda-compat-13-1
+apt-cache policy cuda-compat-13-2
 ```
 
 ### uv

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -52,7 +52,7 @@ commandTests:
   - name: "uvx"
     command: "uvx"
     args: ["--version"]
-    expectedOutput: ["uvx 0.11.9"]
+    expectedOutput: ["uvx 0.11.22"]
 
 fileExistenceTests:
   - name: "/opt/analyticalplatform"

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -42,12 +42,12 @@ commandTests:
   - name: "aws"
     command: "aws"
     args: ["--version"]
-    expectedOutput: ["aws-cli/2.34.39"]
+    expectedOutput: ["aws-cli/2.35.8"]
 
   - name: "uv"
     command: "uv"
     args: ["--version"]
-    expectedOutput: ["uv 0.11.9"]
+    expectedOutput: ["uv 0.11.22"]
 
   - name: "uvx"
     command: "uvx"


### PR DESCRIPTION
This pull request primarily updates the versions of several GitHub Actions workflows and the base Ubuntu image used in the `Dockerfile`. The updates focus on ensuring the use of the latest features, improvements, and security patches from upstream dependencies.

**Workflow version updates:**

* Updated the following reusable workflows to use version `v8.0.1` of `ministryofjustice/analytical-platform-github-actions` instead of `v7.3.0`:
  - `reusable-container-release.yml` in `.github/workflows/container-release.yml`
  - `reusable-container-test.yml` in `.github/workflows/container-test.yml`
  - `reusable-dependency-review.yml` in `.github/workflows/dependency-review.yml`
  - `reusable-super-linter.yml` in `.github/workflows/super-linter.yml`
  - `reusable-zizmor.yml` in `.github/workflows/zizmor.yml`

Dependency and base image updates:

* Updated the base image in `Dockerfile` to a newer Ubuntu 24.04 digest, and upgraded several environment variables: `AWS_CLI_VERSION` to 2.35.8, `CUDA_VERSION` to 13.2.0, `NVIDIA_CUDA_COMPAT_VERSION` and `NVIDIA_CUDA_CUDART_VERSION` to their respective 13.2.x versions, and `UV_VERSION` to 0.11.22. Also added `libgnutls30t64` to the installed packages. 
* Updated CUDA package references in both the `Dockerfile` and `README.md` to use version 13.2 instead of 13.1. 
* Updated expected versions in `test/container-structure-test.yml` to match the new versions of AWS CLI and uv.

CI/CD and workflow improvements:

* Updated multiple GitHub Actions workflow files to use newer reusable workflow versions (`v8.0.1` or `v6.0.0`), improving compatibility and security. 
* Improved permissions handling and upgraded the container scan workflow to use a newer version and explicit permissions.

Vulnerability scanning configuration:

* Added a `.grype.yml` file to ignore a specific CVE (CVE-2026-7210) for container vulnerability scanning.
* Removed `.trivyignore` file, cleaning up old vulnerability ignore rules.

**Base image update:**

* Changed the base image in `Dockerfile` to a newer Ubuntu 24.04 image by updating the SHA256 digest, ensuring the latest security and stability updates are included.