### PR TITLE
Removed unneccessary permission from workflow

### DIFF
--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -13,7 +13,6 @@ jobs:
     name: Scheduled Container Scan
     permissions:
       contents: read
-      id-token: write
     uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scheduled-container-scan.yml@ee7af2fc5379dc235ced9f93378cbca973d9e5ad # v6.0.0
     secrets:
       cve-scan-slack-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_CVE_SCAN_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This pull request makes a minor update to the workflow permissions in `.github/workflows/scheduled-container-scan.yml`, removing the unnecessary `id-token: write` permission from the scheduled container scan job.

- Security and permissions:
  * Removed the `id-token: write` permission from the `Scheduled Container Scan` workflow job in `.github/workflows/scheduled-container-scan.yml` to reduce unnecessary privileges.