### PR TITLE
Fix/scheduled scan

### DIFF
--- a/.github/instructions/patch-apt-packages.instructions.md
+++ b/.github/instructions/patch-apt-packages.instructions.md
@@ -1,0 +1,41 @@
+---
+description: "Use when patching, updating, or bumping apt package versions in the Dockerfile. Covers how to find the latest available version of a package and how to update the pinned version in the apt-get install block."
+applyTo: "Dockerfile"
+---
+
+# Patching APT Packages
+
+APT packages in the Dockerfile are pinned to exact versions using the format `"package=version"`.
+
+## Finding the Latest Version
+
+Spin up the base Ubuntu image (always with `--platform linux/amd64`) and query `apt-cache policy`:
+
+```bash
+docker run -it --rm --platform linux/amd64 public.ecr.aws/ubuntu/ubuntu:24.04
+
+apt-get update
+
+apt-cache policy <package>
+```
+
+The `Candidate:` line in the output is the version to use.
+
+## Updating a Package Version
+
+In the `# Base Configuration` `RUN` block, locate the package in the `apt-get install --yes` block and update its pinned version:
+
+```dockerfile
+apt-get install --yes \
+  "curl=8.5.0-2ubuntu10.9" \
+  "git=1:2.43.0-1ubuntu7.3" \
+  ...
+```
+
+Replace the old version string with the new one. Keep the surrounding double-quotes.
+
+## Rules
+
+- Always use `--platform linux/amd64` when running the Ubuntu image locally — the build target is `x86_64`.
+- Do not remove `apt-get clean --yes` and the `rm --force --recursive /var/lib/apt/lists/*` lines — they are required to keep the image layer small.
+- The base image is defined in the `FROM` line and managed separately by Dependabot — do not change it manually.

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -3,7 +3,7 @@ name: ⏰ Scheduled Container Scan
 
 on:
   schedule:
-    - cron: "05 15 * * 1-5" # Every weekday at 9AM UTC
+    - cron: "11 15 * * 1-5" # Every weekday at 9AM UTC
   workflow_dispatch:
 
 permissions: {}
@@ -15,7 +15,8 @@ jobs:
       contents: read
       security-events: write
     uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scheduled-container-scan.yml@ee7af2fc5379dc235ced9f93378cbca973d9e5ad # v6.0.0
+    with:
+      runtime: python
     secrets:
       cve-scan-slack-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_CVE_SCAN_SLACK_WEBHOOK_URL }}
-    runtime: python 
     

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -3,7 +3,7 @@ name: ⏰ Scheduled Container Scan
 
 on:
   schedule:
-    - cron: "0 15 * * 1-5" # Every weekday at 9AM UTC
+    - cron: "05 15 * * 1-5" # Every weekday at 9AM UTC
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -3,7 +3,7 @@ name: ⏰ Scheduled Container Scan
 
 on:
   schedule:
-    - cron: "0 9 * * 1-5" # Every weekday at 9AM UTC
+    - cron: "0 15 * * 1-5" # Every weekday at 9AM UTC
   workflow_dispatch:
 
 permissions: {}
@@ -13,6 +13,9 @@ jobs:
     name: Scheduled Container Scan
     permissions:
       contents: read
+      security-events: write
     uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scheduled-container-scan.yml@ee7af2fc5379dc235ced9f93378cbca973d9e5ad # v6.0.0
     secrets:
       cve-scan-slack-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_CVE_SCAN_SLACK_WEBHOOK_URL }}
+    runtime: python 
+    

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -19,4 +19,3 @@ jobs:
       runtime: python
     secrets:
       cve-scan-slack-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_CVE_SCAN_SLACK_WEBHOOK_URL }}
-    

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -3,7 +3,7 @@ name: ⏰ Scheduled Container Scan
 
 on:
   schedule:
-    - cron: "11 15 * * 1-5" # Every weekday at 9AM UTC
+    - cron: "0 9 * * 1-5" # Every weekday at 9AM UTC
   workflow_dispatch:
 
 permissions: {}

--- a/.grype.yml
+++ b/.grype.yml
@@ -7,3 +7,4 @@ ignore:
   # Patched upstream, awaiting base image update - see README on how to check for updates.
   - vulnerability: CVE-2026-9669
   # vuln coming from aws cli - waiting for new release of aws cli to fix.
+  

--- a/.grype.yml
+++ b/.grype.yml
@@ -7,4 +7,3 @@ ignore:
   # Patched upstream, awaiting base image update - see README on how to check for updates.
   - vulnerability: CVE-2026-9669
   # vuln coming from aws cli - waiting for new release of aws cli to fix.
-  

--- a/.grype.yml
+++ b/.grype.yml
@@ -5,3 +5,5 @@
 ignore:
   - vulnerability: CVE-2026-7210
   # Patched upstream, awaiting base image update - see README on how to check for updates.
+  - vulnerability: CVE-2026-9669
+  # vuln coming from aws cli - waiting for new release of aws cli to fix.

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV CONTAINER_USER="analyticalplatform" \
     ANALYTICAL_PLATFORM_DIRECTORY="/opt/analyticalplatform" \
     DEBIAN_FRONTEND="noninteractive" \
     PIP_BREAK_SYSTEM_PACKAGES="1" \
-    AWS_CLI_VERSION="2.35.8" \
+    AWS_CLI_VERSION="2.35.12" \
     CUDA_VERSION="13.2.0" \
     NVIDIA_DISABLE_REQUIRE="true" \
     NVIDIA_CUDA_COMPAT_VERSION="595.71.05-1ubuntu1" \
@@ -53,12 +53,16 @@ RUN <<EOF
 apt-get update --yes
 
 apt-get install --yes \
-  "apt-transport-https=2.8.3" \
+  "apt-transport-https=2.8.2" \
   "ca-certificates=20240203" \
-  "curl=8.5.0-2ubuntu10.9" \
+  "curl=8.5.0-2ubuntu10.7" \
   "git=1:2.43.0-1ubuntu7.3" \
   "jq=1.7.1-3ubuntu0.24.04.2" \
   "libgnutls30t64=3.8.3-1.1ubuntu3.6" \
+  "libperl5.38t64=5.38.2-3.2ubuntu0.3" \
+  "perl=5.38.2-3.2ubuntu0.3" \
+  "perl-base=5.38.2-3.2ubuntu0.3" \
+  "perl-modules-5.38=5.38.2-3.2ubuntu0.3" \
   "python3.12=3.12.3-1ubuntu0.13" \
   "python3-pip=24.0+dfsg-1ubuntu1.3" \
   "unzip=6.0-28ubuntu4.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,9 +53,9 @@ RUN <<EOF
 apt-get update --yes
 
 apt-get install --yes \
-  "apt-transport-https=2.8.2" \
-  "ca-certificates=20240203" \
-  "curl=8.5.0-2ubuntu10.7" \
+  "apt-transport-https=2.8.3" \
+  "ca-certificates=20260601~24.04.1" \
+  "curl=8.5.0-2ubuntu10.9" \
   "git=1:2.43.0-1ubuntu7.3" \
   "jq=1.7.1-3ubuntu0.24.04.2" \
   "libgnutls30t64=3.8.3-1.1ubuntu3.6" \

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ docker image inspect --format='{{ index .RepoDigests 0 }}' public.ecr.aws/ubuntu
 
 ### Base APT Packages
 
-The latest versions of the APT packages can be obtained by running the following
+The latest versions of the APT packages can be obtained by asking Copilot to check for apt package updates, or running the following
 
 ```bash
 docker run -it --rm --platform linux/amd64 public.ecr.aws/ubuntu/ubuntu:24.04

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -42,7 +42,7 @@ commandTests:
   - name: "aws"
     command: "aws"
     args: ["--version"]
-    expectedOutput: ["aws-cli/2.35.8"]
+    expectedOutput: ["aws-cli/2.35.12"]
 
   - name: "uv"
     command: "uv"


### PR DESCRIPTION
This pull request updates the Docker image to patch and upgrade several APT packages, most notably bumping the AWS CLI version and updating core system libraries. It also introduces new documentation for maintaining APT package versions, improves the scheduled container scan workflow, and updates vulnerability ignore rules.

**Dependency and Security Updates:**

* Upgraded `AWS_CLI_VERSION` from `2.35.8` to `2.35.12` in the `Dockerfile`, and updated the corresponding test to expect the new version. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L22-R22) [[2]](diffhunk://#diff-44a6e41556139409675f12dd3f067ac9c96930647809395f52f7a9eef8b9a2b5L45-R45)
* Updated pinned APT package versions in the `Dockerfile`, including `ca-certificates`, and added new Perl-related packages to the install list.
* Added `CVE-2026-9669` (related to AWS CLI) to the Grype ignore list while awaiting an upstream fix.

**Documentation Improvements:**

* Added a new `.github/instructions/patch-apt-packages.instructions.md` file with step-by-step guidance on how to patch and update APT packages in the Dockerfile.
* Clarified in `README.md` that Copilot can be used to check for APT package updates, in addition to manual commands.

**Workflow Enhancements:**

* Updated the scheduled container scan workflow to explicitly set the runtime to Python and grant write permissions to `security-events`.