### PR TITLE
update workflow sha

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -15,6 +15,7 @@ jobs:
       id-token: write
       pull-requests: write
       security-events: write
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@ee7af2fc5379dc235ced9f93378cbca973d9e5ad # v6.0.0
+      actions: read
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@613a7cc7496ddaed7ae2b12059177d8aeb0760ae # v7.0.0
     with:
       runtime: python

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scheduled-container-scan.yml@ee7af2fc5379dc235ced9f93378cbca973d9e5ad # v6.0.0
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scheduled-container-scan.yml@613a7cc7496ddaed7ae2b12059177d8aeb0760ae # v7.0.0
     with:
       runtime: python
     secrets:


### PR DESCRIPTION
This pull request updates the container scanning workflows to use the latest versions of the shared GitHub Actions. The main changes are version bumps for the reusable workflows, along with a minor permissions update.

**Workflow updates:**

* Updated the `container-scan.yml` workflow to use `shared-scan-container.yml` from version `v6.0.0` to `v7.0.0`, and added the `actions: read` permission. (.github/workflows/container-scan.yml)
* Updated the `scheduled-container-scan.yml` workflow to use `shared-scheduled-container-scan.yml` from version `v6.0.0` to `v7.0.0`. (.github/workflows/scheduled-container-scan.yml)