### PR TITLE
updated aws cli and uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,14 @@ ENV CONTAINER_USER="analyticalplatform" \
     ANALYTICAL_PLATFORM_DIRECTORY="/opt/analyticalplatform" \
     DEBIAN_FRONTEND="noninteractive" \
     PIP_BREAK_SYSTEM_PACKAGES="1" \
-    AWS_CLI_VERSION="2.35.21" \
+    AWS_CLI_VERSION="2.35.23" \
     CUDA_VERSION="13.2.0" \
     NVIDIA_DISABLE_REQUIRE="true" \
     NVIDIA_CUDA_COMPAT_VERSION="595.71.05-1ubuntu1" \
     NVIDIA_CUDA_CUDART_VERSION="13.2.75-1" \
     NVIDIA_VISIBLE_DEVICES="all" \
     NVIDIA_DRIVER_CAPABILITIES="compute,utility" \
-    UV_VERSION="0.11.27" \
+    UV_VERSION="0.11.28" \
     LD_LIBRARY_PATH="/usr/local/nvidia/lib:/usr/local/nvidia/lib64" \
     PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/home/analyticalplatform/.local/bin:${PATH}"
 

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -52,7 +52,7 @@ commandTests:
   - name: "uvx"
     command: "uvx"
     args: ["--version"]
-    expectedOutput: ["uvx 0.11.27"]
+    expectedOutput: ["uvx 0.11.28"]
 
 fileExistenceTests:
   - name: "/opt/analyticalplatform"

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -42,12 +42,12 @@ commandTests:
   - name: "aws"
     command: "aws"
     args: ["--version"]
-    expectedOutput: ["aws-cli/2.35.21"]
+    expectedOutput: ["aws-cli/2.35.23"]
 
   - name: "uv"
     command: "uv"
     args: ["--version"]
-    expectedOutput: ["uv 0.11.27"]
+    expectedOutput: ["uv 0.11.28"]
 
   - name: "uvx"
     command: "uvx"


### PR DESCRIPTION
This pull request updates the versions of two key dependencies, `aws-cli` and `uv`, in the Docker image and ensures the associated container tests reflect these changes.

Dependency version updates:

* Updated the `AWS_CLI_VERSION` environment variable in the `Dockerfile` from `2.35.21` to `2.35.23` to use the latest version of AWS CLI.
* Updated the `UV_VERSION` environment variable in the `Dockerfile` from `0.11.27` to `0.11.28` to use the latest version of `uv`.

Test updates:

* Updated the expected output for `aws`, `uv`, and `uvx` version checks in `test/container-structure-test.yml` to match the new versions.