### PR TITLE
update uv and add vulns to ignore

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -8,3 +8,7 @@ ignore:
   - vulnerability: CVE-2026-9669
   # vuln coming from aws cli - cannot bump python version
   - vulnerability: CVE-2026-15308
+
+  # transitice dependency - waiting for base image update
+  - vulnerability: CVE-2026-40355
+  - vulnerability: CVE-2026-40356

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV CONTAINER_USER="analyticalplatform" \
     NVIDIA_CUDA_CUDART_VERSION="13.2.75-1" \
     NVIDIA_VISIBLE_DEVICES="all" \
     NVIDIA_DRIVER_CAPABILITIES="compute,utility" \
-    UV_VERSION="0.11.28" \
+    UV_VERSION="0.11.31" \
     LD_LIBRARY_PATH="/usr/local/nvidia/lib:/usr/local/nvidia/lib64" \
     PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/home/analyticalplatform/.local/bin:${PATH}"
 

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -47,12 +47,12 @@ commandTests:
   - name: "uv"
     command: "uv"
     args: ["--version"]
-    expectedOutput: ["uv 0.11.28"]
+    expectedOutput: ["uv 0.11.31"]
 
   - name: "uvx"
     command: "uvx"
     args: ["--version"]
-    expectedOutput: ["uvx 0.11.28"]
+    expectedOutput: ["uvx 0.11.31"]
 
 fileExistenceTests:
   - name: "/opt/analyticalplatform"


### PR DESCRIPTION
This pull request updates the `uv` tool to version 0.11.31 and adds new vulnerability ignores for transitive dependencies. The most important changes are summarized below:

Dependency updates:
* Updated the `UV_VERSION` environment variable in the `Dockerfile` from `0.11.28` to `0.11.31`, ensuring the container uses the latest compatible version of `uv`.
* Updated the expected output in `test/container-structure-test.yml` to match the new `uv` and `uvx` version (`0.11.31`) in command tests.

Security configuration:
* Added ignores for vulnerabilities `CVE-2026-40355` and `CVE-2026-40356` in `.grype.yml` as they are present in transitive dependencies and pending a base image update.