### PR TITLE
Fix critical CVE alerts in Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,11 @@ apt-get install --yes \
   "libncursesw6=6.4+20240113-1ubuntu2.1" \
   "libtinfo6=6.4+20240113-1ubuntu2.1" \
   "libperl5.38t64=5.38.2-3.2ubuntu0.3" \
+  "libc-bin=2.39-0ubuntu8.8" \
+  "libc-dev-bin=2.39-0ubuntu8.8" \
+  "libc-devtools=2.39-0ubuntu8.8" \
+  "libc6=2.39-0ubuntu8.8" \
+  "libc6-dev=2.39-0ubuntu8.8" \
   "ncurses-base=6.4+20240113-1ubuntu2.1" \
   "ncurses-bin=6.4+20240113-1ubuntu2.1" \
   "perl=5.38.2-3.2ubuntu0.3" \


### PR DESCRIPTION
This pull request updates the `Dockerfile` to explicitly install several `libc6`-related packages at version `2.39-0ubuntu8.8`. This ensures the container uses a consistent and up-to-date version of the C library and related development tools.

Dependency updates:

* Added `libc-bin`, `libc-dev-bin`, `libc-devtools`, `libc6`, and `libc6-dev` (all at version `2.39-0ubuntu8.8`) to the list of packages installed with `apt-get` to ensure the correct C library and development environment are present.